### PR TITLE
Header improvements: brand nav, profile/settings links, dropdown alignment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,8 @@ const Customers = lazy(() => import("./pages/Customers"));
 const Items = lazy(() => import("./pages/Items"));
 const DocumentCreation = lazy(() => import("./pages/DocumentCreation"));
 const DocumentEdit = lazy(() => import("./pages/DocumentEdit"));
+const Profile = lazy(() => import("./pages/Profile"));
+const Settings = lazy(() => import("./pages/Settings"));
 
 function App() {
   return (
@@ -32,6 +34,8 @@ function App() {
             <Route path="dashboard" element={<Dashboard />} />
             <Route path="customers" element={<Customers />} />
             <Route path="items" element={<Items />} />
+            <Route path="profile" element={<Profile />} />
+            <Route path="settings" element={<Settings />} />
             <Route path="documents">
               <Route path="new" element={<DocumentCreation />} />
               <Route path=":id/edit" element={<DocumentEdit />} />

--- a/src/components/core/Header.tsx
+++ b/src/components/core/Header.tsx
@@ -38,10 +38,14 @@ const Header: React.FC<HeaderProps> = () => {
   return (
     <header className="top-header">
       <div className="top-header__inner">
-        <div className="brand-group">
+        <NavLink
+          to="/dashboard"
+          className="brand-group"
+          aria-label="Go to dashboard"
+        >
           <img src={Logo} alt="SimpleBill logo" className="brand-icon" />
           <h1 className="brand-title">SimpleBill</h1>
-        </div>
+        </NavLink>
 
         <nav className="nav-links">
           <NavLink to="/dashboard" className={navClass} end>
@@ -93,8 +97,26 @@ const Header: React.FC<HeaderProps> = () => {
                 <div className="menu-user">{user?.displayName ?? "User"}</div>
                 {user?.email && <div className="menu-email">{user.email}</div>}
               </div>
+              <div className="menu-links">
+                <NavLink
+                  to="/profile"
+                  className="menu-link"
+                  role="menuitem"
+                  onClick={() => setMenuOpen(false)}
+                >
+                  Profile
+                </NavLink>
+                <NavLink
+                  to="/settings"
+                  className="menu-link"
+                  role="menuitem"
+                  onClick={() => setMenuOpen(false)}
+                >
+                  Settings
+                </NavLink>
+              </div>
               <button
-                className="menu-item"
+                className="menu-item menu-item--center"
                 role="menuitem"
                 onClick={handleSignOut}
               >

--- a/src/index.css
+++ b/src/index.css
@@ -16,14 +16,25 @@
 }
 
 body {
-  font-family: 'Atkinson Hyperlegible', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  font-family:
+    "Atkinson Hyperlegible",
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Arial,
+    sans-serif;
   background-color: var(--brand-background);
   margin: 0;
   min-height: 100vh;
 }
 
-h1, h2, h3, .brand, .primary-cta {
-  font-family: 'Caveat', 'Atkinson Hyperlegible', system-ui, sans-serif;
+h1,
+h2,
+h3,
+.brand,
+.primary-cta {
+  font-family: "Caveat", "Atkinson Hyperlegible", system-ui, sans-serif;
 }
 
 .btn-primary {
@@ -53,18 +64,58 @@ h1, h2, h3, .brand, .primary-cta {
   max-width: 1440px;
   margin: 0 auto;
 }
-@media (min-width: 1024px) { .top-header__inner { padding: 0 2rem; } }
-.brand-group { display: flex; align-items: center; gap: 0.75rem; }
-.brand-icon { width: 44px; height: 44px; color: var(--brand-primary); object-fit: contain; display: block; }
-.brand-title { font-size: 1.25rem; font-weight: 700; margin: 0; }
+@media (min-width: 1024px) {
+  .top-header__inner {
+    padding: 0 2rem;
+  }
+}
+.brand-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+.brand-icon {
+  width: 44px;
+  height: 44px;
+  color: var(--brand-primary);
+  object-fit: contain;
+  display: block;
+}
+.brand-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+}
 
-.nav-links { display: none; align-items: center; gap: 1.25rem; }
-@media (min-width: 1024px) { .nav-links { display: flex; } }
-.nav-link { font-size: 1rem; font-weight: 600; color: var(--brand-text-secondary); text-decoration: none; }
-.nav-link:hover { color: var(--brand-primary); }
-.nav-link.active { color: var(--brand-primary); font-weight: 600; }
+.nav-links {
+  display: none;
+  align-items: center;
+  gap: 1.25rem;
+}
+@media (min-width: 1024px) {
+  .nav-links {
+    display: flex;
+  }
+}
+.nav-link {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--brand-text-secondary);
+  text-decoration: none;
+}
+.nav-link:hover {
+  color: var(--brand-primary);
+}
+.nav-link.active {
+  color: var(--brand-primary);
+  font-weight: 600;
+}
 
-.header-actions { display: flex; align-items: center; gap: 0.75rem; }
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
 .icon-button {
   border: none;
   background: transparent;
@@ -76,8 +127,14 @@ h1, h2, h3, .brand, .primary-cta {
   place-items: center;
   padding: 0;
 }
-.icon-button:hover { background: #f0f2f4; }
-.avatar-button { display: grid; place-items: center; padding: 0; }
+.icon-button:hover {
+  background: #f0f2f4;
+}
+.avatar-button {
+  display: grid;
+  place-items: center;
+  padding: 0;
+}
 .avatar {
   width: var(--avatar-size);
   height: var(--avatar-size);
@@ -90,18 +147,93 @@ h1, h2, h3, .brand, .primary-cta {
   color: var(--brand-text-primary);
   font-weight: 700;
 }
-.avatar img { display: block; width: 100%; height: 100%; object-fit: cover; vertical-align: middle; }
+.avatar img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  vertical-align: middle;
+}
 
 /* User menu */
-.user-menu { position: relative; }
-.avatar-button { border: none; background: transparent; padding: 0; cursor: pointer; }
-.menu-dropdown { position: absolute; right: 0; top: calc(100% + 8px); width: 220px; background: #fff; border: 1px solid var(--brand-border); border-radius: 10px; box-shadow: 0 6px 24px rgba(0,0,0,0.08); padding: 8px; display: none; }
-.menu-dropdown.open { display: block; }
-.menu-header { padding: 8px; border-bottom: 1px solid var(--brand-border); margin-bottom: 6px; }
-.menu-user { font-weight: 700; color: var(--brand-text-primary); font-size: 0.95rem; }
-.menu-email { color: var(--brand-text-secondary); font-size: 0.8rem; }
-.menu-item { width: 100%; text-align: left; background: #fff; border: 1px solid var(--brand-border); padding: 8px 10px; border-radius: 8px; cursor: pointer; font-weight: 600; color: var(--brand-text-primary); }
-.menu-item:hover { background: var(--brand-background); }
+.user-menu {
+  position: relative;
+}
+.avatar-button {
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+}
+.menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  width: 220px;
+  background: #fff;
+  border: 1px solid var(--brand-border);
+  border-radius: 10px;
+  box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
+  padding: 8px;
+  display: none;
+}
+.menu-dropdown.open {
+  display: block;
+}
+.menu-header {
+  padding: 8px;
+  border-bottom: 1px solid var(--brand-border);
+  margin-bottom: 6px;
+}
+.menu-user {
+  font-weight: 700;
+  color: var(--brand-text-primary);
+  font-size: 0.95rem;
+}
+.menu-email {
+  color: var(--brand-text-secondary);
+  font-size: 0.8rem;
+}
+.menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: #fff;
+  border: 1px solid var(--brand-border);
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--brand-text-primary);
+  text-decoration: none;
+  margin: 6px 0;
+}
+.menu-item:hover {
+  background: var(--brand-background);
+}
+.menu-item--center {
+  text-align: center;
+}
+/* Inline links (Profile / Settings) */
+.menu-links {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 6px 8px;
+  width: 100%;
+}
+.menu-link {
+  background: transparent;
+  border: none;
+  color: var(--brand-text-primary);
+  font-weight: 700;
+  text-decoration: none;
+  padding: 0;
+}
+.menu-link:hover {
+  text-decoration: underline;
+}
 
 /* Dashboard styles */
 .container-xl {
@@ -170,9 +302,17 @@ h1, h2, h3, .brand, .primary-cta {
   font-weight: 600;
   cursor: pointer;
 }
-.link-btn:hover { text-decoration: underline; }
-.link-btn.link-danger { color: var(--brand-danger); }
-.table .actions { display: inline-flex; align-items: center; gap: 20px; }
+.link-btn:hover {
+  text-decoration: underline;
+}
+.link-btn.link-danger {
+  color: var(--brand-danger);
+}
+.table .actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 20px;
+}
 
 .status-badge {
   display: inline-flex;
@@ -182,22 +322,45 @@ h1, h2, h3, .brand, .primary-cta {
   font-size: 0.75rem;
   font-weight: 600;
 }
-.status-finalized { background: var(--green-light); color: var(--green-dark); }
-.status-draft { background: var(--orange-light); color: var(--orange-dark); }
+.status-finalized {
+  background: var(--green-light);
+  color: var(--green-dark);
+}
+.status-draft {
+  background: var(--orange-light);
+  color: var(--orange-dark);
+}
 
 /* Responsive list cards for mobile */
-.doc-cards { display: none; gap: 1rem; }
+.doc-cards {
+  display: none;
+  gap: 1rem;
+}
 .doc-card {
   background: var(--white);
   border: 1px solid var(--brand-border);
   border-radius: 12px;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
 }
-.doc-card .body { padding: 16px; }
-.doc-card .row { display: flex; align-items: center; justify-content: space-between; }
-.doc-card .muted { color: var(--brand-text-secondary); font-size: 0.9rem; }
+.doc-card .body {
+  padding: 16px;
+}
+.doc-card .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.doc-card .muted {
+  color: var(--brand-text-secondary);
+  font-size: 0.9rem;
+}
 
 @media (max-width: 768px) {
-  .table-wrapper { display: none; }
-  .doc-cards { display: grid; grid-template-columns: 1fr; }
+  .table-wrapper {
+    display: none;
+  }
+  .doc-cards {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useAuth } from "@auth/useAuth";
+
+const Profile: React.FC = () => {
+  const { user } = useAuth();
+  return (
+    <div style={{ maxWidth: 640 }}>
+      <h2>Profile</h2>
+      <div style={{ marginTop: 12 }}>
+        <div>
+          <strong>Name:</strong> {user?.displayName ?? "—"}
+        </div>
+        <div>
+          <strong>Email:</strong> {user?.email ?? "—"}
+        </div>
+        <div>
+          <strong>UID:</strong> {user?.uid ?? "—"}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Profile;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const Settings: React.FC = () => {
+  return (
+    <div style={{ maxWidth: 640 }}>
+      <h2>Settings</h2>
+      <p style={{ marginTop: 12 }}>Coming soon.</p>
+    </div>
+  );
+};
+
+export default Settings;


### PR DESCRIPTION
This PR updates the header:

- Make brand (logo + title) clickable to navigate to /dashboard
- Add Profile and Settings links to the user dropdown
- Stack links, left-align them, and increase spacing
- Center the "Sign out" button text
- Add routes and minimal pages for /profile and /settings

Build passes locally.

