### PR TITLE
feat(appshell): add responsive left sidebar; remove top header; move user menu to sidebar footer

### DIFF
--- a/src/components/core/Header.tsx
+++ b/src/components/core/Header.tsx
@@ -1,12 +1,11 @@
 import React, { useEffect, useRef, useState } from "react";
 import { NavLink } from "react-router-dom";
-import Logo from "@assets/logo.svg";
 import { useAuth } from "@auth/useAuth";
 import { getFallbackAvatar } from "@utils/fallbackAvatar";
 
-type HeaderProps = { title?: string };
+type HeaderProps = { title?: string; onToggleSidebar?: () => void };
 
-const Header: React.FC<HeaderProps> = () => {
+const Header: React.FC<HeaderProps> = ({ title, onToggleSidebar }) => {
   const { user, signOut } = useAuth();
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement | null>(null);
@@ -32,32 +31,21 @@ const Header: React.FC<HeaderProps> = () => {
     await signOut();
   };
 
-  const navClass = ({ isActive }: { isActive: boolean }) =>
-    `nav-link${isActive ? " active" : ""}`;
-
   return (
     <header className="top-header">
       <div className="top-header__inner">
-        <NavLink
-          to="/dashboard"
-          className="brand-group"
-          aria-label="Go to dashboard"
-        >
-          <img src={Logo} alt="SimpleBill logo" className="brand-icon" />
-          <h1 className="brand-title">SimpleBill</h1>
-        </NavLink>
-
-        <nav className="nav-links">
-          <NavLink to="/dashboard" className={navClass} end>
-            Dashboard
-          </NavLink>
-          <NavLink to="/customers" className={navClass}>
-            Customers
-          </NavLink>
-          <NavLink to="/items" className={navClass}>
-            Items
-          </NavLink>
-        </nav>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <button
+            className="hamburger-btn"
+            aria-label="Open sidebar"
+            onClick={onToggleSidebar}
+          >
+            <span aria-hidden>☰</span>
+          </button>
+          <h2 className="page-title" style={{ margin: 0 }}>
+            {title || ""}
+          </h2>
+        </div>
 
         <div className="header-actions">
           <div className="user-menu" ref={menuRef}>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,16 +1,53 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { NavLink, Outlet } from "react-router-dom";
-import Header from "../core/Header";
 import Logo from "../../assets/logo.svg";
 import { PageTitleContext } from "./PageTitleContext";
+import { useAuth } from "@auth/useAuth";
+import { getFallbackAvatar } from "@utils/fallbackAvatar";
 
 const AppShell: React.FC = () => {
   const [pageTitle, setPageTitle] = useState<string>("");
   const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+  const { user, signOut } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
   const pageTitleCtx = useMemo(() => ({ setTitle: setPageTitle }), []);
-  const handleToggleSidebar = useCallback(() => setSidebarOpen((v) => !v), []);
   const handleCloseSidebar = useCallback(() => setSidebarOpen(false), []);
+  const handleSignOut = async () => {
+    setMenuOpen(false);
+    await signOut();
+  };
+
+  useEffect(() => {
+    if (pageTitle && pageTitle.trim().length > 0) {
+      document.title = `${pageTitle} · SimpleBill`;
+    } else {
+      document.title = "SimpleBill";
+    }
+  }, [pageTitle]);
+
+  useEffect(() => {
+    const onDocClick = (e: MouseEvent) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(e.target as Node)) setMenuOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, []);
 
   return (
     <PageTitleContext.Provider value={pageTitleCtx}>
@@ -35,12 +72,13 @@ const AppShell: React.FC = () => {
               <img src={Logo} alt="SimpleBill" className="brand-icon" />
               <span className="brand-title">SimpleBill</span>
             </div>
-            <nav className="sidebar-nav">
+            <nav className="sidebar-nav" style={{ flex: 1 }}>
               <NavLink
                 to="/dashboard"
                 className={({ isActive }) =>
                   `sidebar-link${isActive ? " active" : ""}`
                 }
+                onClick={handleCloseSidebar}
                 end
               >
                 Dashboard
@@ -50,6 +88,7 @@ const AppShell: React.FC = () => {
                 className={({ isActive }) =>
                   `sidebar-link${isActive ? " active" : ""}`
                 }
+                onClick={handleCloseSidebar}
               >
                 Customers
               </NavLink>
@@ -58,6 +97,7 @@ const AppShell: React.FC = () => {
                 className={({ isActive }) =>
                   `sidebar-link${isActive ? " active" : ""}`
                 }
+                onClick={handleCloseSidebar}
               >
                 Items
               </NavLink>
@@ -67,6 +107,7 @@ const AppShell: React.FC = () => {
                 className={({ isActive }) =>
                   `sidebar-link${isActive ? " active" : ""}`
                 }
+                onClick={handleCloseSidebar}
               >
                 Profile
               </NavLink>
@@ -75,26 +116,94 @@ const AppShell: React.FC = () => {
                 className={({ isActive }) =>
                   `sidebar-link${isActive ? " active" : ""}`
                 }
+                onClick={handleCloseSidebar}
               >
                 Settings
               </NavLink>
             </nav>
+
+            <div className="sidebar-user">
+              <div className="user-menu" ref={menuRef}>
+                <button
+                  className="avatar-button"
+                  aria-haspopup="menu"
+                  aria-expanded={menuOpen}
+                  onClick={() => setMenuOpen((v) => !v)}
+                >
+                  <div className="avatar" title={user?.displayName ?? "User"}>
+                    <img
+                      src={
+                        user?.photoURL ||
+                        getFallbackAvatar({
+                          uid: user?.uid,
+                          email: user?.email,
+                          displayName: user?.displayName,
+                        })
+                      }
+                      alt="User avatar"
+                      referrerPolicy="no-referrer"
+                      onError={(e) => {
+                        e.currentTarget.src = getFallbackAvatar({
+                          uid: user?.uid,
+                          email: user?.email,
+                          displayName: user?.displayName,
+                        });
+                      }}
+                    />
+                  </div>
+                </button>
+                <div
+                  className={`menu-dropdown ${menuOpen ? "open" : ""}`}
+                  role="menu"
+                >
+                  <div className="menu-header">
+                    <div className="menu-user">
+                      {user?.displayName ?? "User"}
+                    </div>
+                    {user?.email && (
+                      <div className="menu-email">{user.email}</div>
+                    )}
+                  </div>
+                  <div className="menu-links">
+                    <NavLink
+                      to="/profile"
+                      className="menu-link"
+                      role="menuitem"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      Profile
+                    </NavLink>
+                    <NavLink
+                      to="/settings"
+                      className="menu-link"
+                      role="menuitem"
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      Settings
+                    </NavLink>
+                  </div>
+                  <button
+                    className="menu-item menu-item--center"
+                    role="menuitem"
+                    onClick={handleSignOut}
+                  >
+                    Sign out
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
+        </aside>
+        <div className="main-area">
+          <main className="main-content">
+            <Outlet />
+          </main>
           {/* Mobile overlay to close */}
           <button
             className="sidebar-overlay"
             aria-label="Close sidebar"
             onClick={handleCloseSidebar}
           />
-        </aside>
-        <div className="main-area">
-          <Header
-            title={pageTitle || ""}
-            onToggleSidebar={handleToggleSidebar}
-          />
-          <main className="main-content">
-            <Outlet />
-          </main>
         </div>
       </div>
     </PageTitleContext.Provider>

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,15 +1,103 @@
-import React from 'react';
-import { Outlet } from 'react-router-dom';
-import Header from '../core/Header';
+import React, { useCallback, useMemo, useState } from "react";
+import { NavLink, Outlet } from "react-router-dom";
+import Header from "../core/Header";
+import Logo from "../../assets/logo.svg";
+import { PageTitleContext } from "./PageTitleContext";
 
 const AppShell: React.FC = () => {
+  const [pageTitle, setPageTitle] = useState<string>("");
+  const [sidebarOpen, setSidebarOpen] = useState<boolean>(false);
+
+  const pageTitleCtx = useMemo(() => ({ setTitle: setPageTitle }), []);
+  const handleToggleSidebar = useCallback(() => setSidebarOpen((v) => !v), []);
+  const handleCloseSidebar = useCallback(() => setSidebarOpen(false), []);
+
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
-      <Header />
-      <main style={{ flex: 1, padding: '1rem' }}>
-        <Outlet />
-      </main>
-    </div>
+    <PageTitleContext.Provider value={pageTitleCtx}>
+      <div
+        className="app-layout"
+        style={{
+          minHeight: "100vh",
+          display: "grid",
+          gridTemplateColumns: "auto 1fr",
+        }}
+      >
+        <aside
+          className="sidebar"
+          data-open={sidebarOpen ? "true" : "false"}
+          onClick={(e) => {
+            // prevent clicks inside from bubbling to overlay handler
+            e.stopPropagation();
+          }}
+        >
+          <div className="sidebar-inner">
+            <div className="sidebar-brand">
+              <img src={Logo} alt="SimpleBill" className="brand-icon" />
+              <span className="brand-title">SimpleBill</span>
+            </div>
+            <nav className="sidebar-nav">
+              <NavLink
+                to="/dashboard"
+                className={({ isActive }) =>
+                  `sidebar-link${isActive ? " active" : ""}`
+                }
+                end
+              >
+                Dashboard
+              </NavLink>
+              <NavLink
+                to="/customers"
+                className={({ isActive }) =>
+                  `sidebar-link${isActive ? " active" : ""}`
+                }
+              >
+                Customers
+              </NavLink>
+              <NavLink
+                to="/items"
+                className={({ isActive }) =>
+                  `sidebar-link${isActive ? " active" : ""}`
+                }
+              >
+                Items
+              </NavLink>
+              <div className="sidebar-sep" />
+              <NavLink
+                to="/profile"
+                className={({ isActive }) =>
+                  `sidebar-link${isActive ? " active" : ""}`
+                }
+              >
+                Profile
+              </NavLink>
+              <NavLink
+                to="/settings"
+                className={({ isActive }) =>
+                  `sidebar-link${isActive ? " active" : ""}`
+                }
+              >
+                Settings
+              </NavLink>
+            </nav>
+          </div>
+          {/* Mobile overlay to close */}
+          <button
+            className="sidebar-overlay"
+            aria-label="Close sidebar"
+            onClick={handleCloseSidebar}
+          />
+        </aside>
+        <div className="main-area">
+          <Header
+            title={pageTitle || ""}
+            onToggleSidebar={handleToggleSidebar}
+          />
+          <main className="main-content">
+            <Outlet />
+          </main>
+        </div>
+      </div>
+    </PageTitleContext.Provider>
   );
 };
 

--- a/src/components/layout/PageTitleContext.tsx
+++ b/src/components/layout/PageTitleContext.tsx
@@ -1,0 +1,16 @@
+import { createContext, useContext, useEffect } from "react";
+
+export type PageTitleContextType = {
+  setTitle: (title: string) => void;
+};
+
+export const PageTitleContext = createContext<PageTitleContextType | null>(
+  null,
+);
+
+export function usePageTitle(title: string) {
+  const ctx = useContext(PageTitleContext);
+  useEffect(() => {
+    ctx?.setTitle(title);
+  }, [ctx, title]);
+}

--- a/src/index.css
+++ b/src/index.css
@@ -28,6 +28,111 @@ body {
   margin: 0;
   min-height: 100vh;
 }
+/* App layout */
+.app-layout {
+  grid-template-columns: 260px 1fr;
+}
+
+.sidebar {
+  position: relative;
+  background: var(--white);
+  border-right: 1px solid var(--brand-border);
+  min-height: 100vh;
+}
+.sidebar-inner {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1rem 0.5rem 1rem;
+}
+.sidebar-nav {
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem 0.5rem 1rem 0.5rem;
+  gap: 4px;
+}
+.sidebar-link {
+  display: block;
+  padding: 10px 12px;
+  border-radius: 8px;
+  color: var(--brand-text-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+.sidebar-link:hover {
+  background: var(--brand-background);
+}
+.sidebar-link.active {
+  color: var(--brand-primary);
+}
+.sidebar-sep {
+  height: 1px;
+  background: var(--brand-border);
+  margin: 8px 8px;
+}
+
+.main-area {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.main-content {
+  flex: 1;
+  padding: 1rem;
+}
+
+/* Header tweaks for title + hamburger */
+.hamburger-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid var(--brand-border);
+  background: var(--white);
+  cursor: pointer;
+}
+.hamburger-btn:hover {
+  background: #f5f7fb;
+}
+.page-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+/* Mobile responsive sidebar */
+@media (max-width: 1023px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+  .sidebar {
+    position: fixed;
+    inset: 0 auto 0 0;
+    width: 280px;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    z-index: 20;
+  }
+  .sidebar[data-open="true"] {
+    transform: translateX(0);
+  }
+  .sidebar-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.25);
+    display: none;
+    border: none;
+  }
+  .sidebar[data-open="true"] + .main-area .sidebar-overlay {
+    display: block;
+  }
+}
 
 h1,
 h2,

--- a/src/index.css
+++ b/src/index.css
@@ -76,6 +76,12 @@ body {
   margin: 8px 8px;
 }
 
+.sidebar-user {
+  margin-top: auto;
+  padding: 0.75rem;
+  border-top: 1px solid var(--brand-border);
+}
+
 .main-area {
   display: flex;
   flex-direction: column;
@@ -129,7 +135,10 @@ body {
     display: none;
     border: none;
   }
-  .sidebar[data-open="true"] + .main-area .sidebar-overlay {
+  .main-area .sidebar-overlay {
+    display: none;
+  }
+  .sidebar[data-open="true"] ~ .main-area .sidebar-overlay {
     display: block;
   }
 }

--- a/src/pages/Customers.tsx
+++ b/src/pages/Customers.tsx
@@ -7,8 +7,10 @@ import CustomerModal, {
   type CustomerFormData,
 } from "@components/customers/CustomerModal";
 import type { Customer } from "../types/customer";
+import { usePageTitle } from "@components/layout/PageTitleContext";
 
 const Customers: React.FC = () => {
+  usePageTitle("Customers");
   const { user } = useAuth();
   type CustomerRow = Customer & { addressDisplay: string };
   const { items, loading, error, add, update, remove } = useFirestore<

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -5,12 +5,14 @@ import ErrorBanner from "@components/core/ErrorBanner";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@auth/useAuth";
 import { useFirestore } from "@hooks/useFirestore";
+import { usePageTitle } from "@components/layout/PageTitleContext";
 import type { DocumentEntity } from "../types/document";
 import { formatCurrency } from "@utils/currency";
 import { downloadBlob } from "@utils/download";
 import { getDocumentFilename } from "@utils/documents";
 
 const Dashboard: React.FC = () => {
+  usePageTitle("Dashboard");
   const navigate = useNavigate();
   const { user } = useAuth();
   type DocumentRow = DocumentEntity & {
@@ -55,9 +57,6 @@ const Dashboard: React.FC = () => {
     <div style={{ padding: "1rem" }}>
       <div className="container-xl">
         <div className="page-header">
-          <h2 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>
-            Dashboard
-          </h2>
           <div style={{ display: "flex", gap: 8 }}>
             <PrimaryButton onClick={() => navigate("/documents/new")}>
               Create New Document

--- a/src/pages/DocumentCreation.tsx
+++ b/src/pages/DocumentCreation.tsx
@@ -30,8 +30,10 @@ import {
   getDefaultInitialState,
 } from "@hooks/useDocumentForm";
 import { validateDraft, validateFinalize } from "@utils/documentValidation";
+import { usePageTitle } from "@components/layout/PageTitleContext";
 
 const DocumentCreation: React.FC = () => {
+  usePageTitle("Create Document");
   const navigate = useNavigate();
   const { user } = useAuth();
 

--- a/src/pages/DocumentEdit.tsx
+++ b/src/pages/DocumentEdit.tsx
@@ -51,8 +51,10 @@ import {
   validateDraft as validateDraftShared,
   validateFinalize as validateFinalizeShared,
 } from "@utils/documentValidation";
+import { usePageTitle } from "@components/layout/PageTitleContext";
 
 const DocumentEdit: React.FC = () => {
+  usePageTitle("Edit Document");
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
   const { user } = useAuth();

--- a/src/pages/Items.tsx
+++ b/src/pages/Items.tsx
@@ -5,8 +5,10 @@ import { useAuth } from "@auth/useAuth";
 import { useFirestore } from "@hooks/useFirestore";
 import ItemModal, { type ItemFormData } from "@components/items/ItemModal";
 import type { Item } from "../types/item";
+import { usePageTitle } from "@components/layout/PageTitleContext";
 
 const Items: React.FC = () => {
+  usePageTitle("Items");
   const { user } = useAuth();
   type ItemRow = Item & { unitPriceLabel: string };
   const { items, loading, error, add, update, remove } = useFirestore<

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 import { useAuth } from "@auth/useAuth";
+import { usePageTitle } from "@components/layout/PageTitleContext";
 
 const Profile: React.FC = () => {
+  usePageTitle("Profile");
   const { user } = useAuth();
   return (
     <div style={{ maxWidth: 640 }}>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { usePageTitle } from "@components/layout/PageTitleContext";
 
 const Settings: React.FC = () => {
+  usePageTitle("Settings");
   return (
     <div style={{ maxWidth: 640 }}>
       <h2>Settings</h2>


### PR DESCRIPTION
This PR introduces a left sidebar AppShell and moves the user menu to the sidebar footer.

- Remove top Header from authenticated layout; content renders directly under main area
- Add user avatar + dropdown (Profile, Settings, Sign out) at bottom of sidebar (.sidebar-user)
- Wire existing auth menu logic (open/close, sign out) within sidebar
- Add sidebar styles and mobile overlay behavior in index.css
- Keep page title context for future surface areas

Co-authored-by: donkasun <kasungallage94@gmail.com>